### PR TITLE
smbtorture: add failing samba3.smb2.deny.* tests to flapping tests

### DIFF
--- a/testcases/smbtorture/selftest/flapping.gluster
+++ b/testcases/smbtorture/selftest/flapping.gluster
@@ -7,3 +7,6 @@
 # This is a known fail for samba4 env. We explicitly mark env as
 # samba3 which means we don't ever match with this knownfail.
 ^samba3.smb2.create.quota-fake-file
+
+#https://github.com/gluster/samba-integration/issues/241
+^samba3.smb2.deny.*


### PR DESCRIPTION
These tests  are being investigated at
https://github.com/gluster/samba-integration/issues/241

and it appears that these are caused by a bug in glusterfs.