### PR TITLE
pyproject: add 'py-modules' entry for 'setuptools'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ authors = [
     {name = "Shachar Sharon", email = "ssharon@ibm.com"},
 ]
 
+[tool.setuptools]
+py-modules = [ "testcases", "testhelper" ]
+
 [tool.setuptools_scm]
 
 [tool.black]


### PR DESCRIPTION
Having multiple packages layout requires explicit 'py-modules' entry for setuptools in order to avoid failures due to "Multiple top-level packages discovered in a flat-layout".