### PR TITLE
mypy type hints

### DIFF
--- a/testcases/consistency/test_consistency.py
+++ b/testcases/consistency/test_consistency.py
@@ -18,12 +18,12 @@ test_string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 test_info: typing.Dict[str, typing.Any] = {}
 
 
-def file_content_check(f, comp_str):
+def file_content_check(f: typing.IO, comp_str: str) -> bool:
     read_data = f.read()
     return read_data == comp_str
 
 
-def consistency_check(mount_point, ipaddr, share_name):
+def consistency_check(mount_point: str, ipaddr: str, share_name: str) -> None:
     mount_params = testhelper.get_mount_parameters(test_info, share_name)
     mount_params["host"] = ipaddr
     try:
@@ -55,9 +55,11 @@ def consistency_check(mount_point, ipaddr, share_name):
             os.unlink(test_file_resp)
 
 
-def generate_consistency_check(test_info_file):
+def generate_consistency_check(
+    test_info_file: typing.Optional[str],
+) -> typing.List[typing.Tuple[str, str]]:
     global test_info
-    if test_info_file is None:
+    if not test_info_file:
         return []
     test_info = testhelper.read_yaml(test_info_file)
     arr = []
@@ -71,7 +73,7 @@ def generate_consistency_check(test_info_file):
     "ipaddr,share_name",
     generate_consistency_check(os.getenv("TEST_INFO_FILE")),
 )
-def test_consistency(ipaddr, share_name):
+def test_consistency(ipaddr: str, share_name: str) -> None:
     tmp_root = testhelper.get_tmp_root()
     mount_point = testhelper.get_tmp_mount_point(tmp_root)
     consistency_check(mount_point, ipaddr, share_name)

--- a/testcases/mount/test_mount.py
+++ b/testcases/mount/test_mount.py
@@ -10,7 +10,7 @@ import sys
 test_string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 
-def mount_test(test_info):
+def mount_test(test_info: dict) -> None:
     tmp_root = testhelper.get_tmp_root()
     mount_point = testhelper.get_tmp_mount_point(tmp_root)
     mount_params = testhelper.get_default_mount_params(test_info)
@@ -47,10 +47,11 @@ def mount_test(test_info):
         os.rmdir(tmp_root)
 
 
-def test_mount():
+def test_mount() -> None:
     test_info_file = os.getenv("TEST_INFO_FILE")
-    test_info = testhelper.read_yaml(test_info_file)
-    mount_test(test_info)
+    if test_info_file:
+        test_info = testhelper.read_yaml(test_info_file)
+        mount_test(test_info)
 
 
 if __name__ == "__main__":

--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -23,7 +23,7 @@ test_info: typing.Dict[str, typing.Any] = {}
 output = testhelper.get_tmp_file("/tmp")
 
 
-def smbtorture(share_name, test, output):
+def smbtorture(share_name: str, test: str, output: str) -> bool:
     mount_params = testhelper.get_mount_parameters(test_info, share_name)
 
     smbtorture_options_str = (
@@ -98,9 +98,11 @@ def list_smbtorture_tests(test_info):
     return smbtorture_info
 
 
-def generate_smbtorture_tests(test_info_file):
+def generate_smbtorture_tests(
+    test_info_file: typing.Optional[str],
+) -> typing.List[typing.Tuple[str, str]]:
     global test_info
-    if test_info_file is None:
+    if not test_info_file:
         return []
     test_info = testhelper.read_yaml(test_info_file)
     smbtorture_info = list_smbtorture_tests(test_info)
@@ -115,7 +117,7 @@ def generate_smbtorture_tests(test_info_file):
 @pytest.mark.parametrize(
     "share_name,test", generate_smbtorture_tests(os.getenv("TEST_INFO_FILE"))
 )
-def test_smbtorture(share_name, test):
+def test_smbtorture(share_name: str, test: str) -> bool:
     ret = smbtorture(share_name, test, output)
     if not ret:
         with open(output) as f:

--- a/testhelper/cmdhelper.py
+++ b/testhelper/cmdhelper.py
@@ -1,8 +1,11 @@
 import os
 import subprocess
+import typing
 
 
-def cifs_mount(mount_params, mount_point, opts=None):
+def cifs_mount(
+    mount_params: typing.Dict[str, str], mount_point: str, opts: str = ""
+) -> int:
     """Use the cifs module to mount a share.
 
     Parameters:
@@ -36,7 +39,7 @@ def cifs_mount(mount_params, mount_point, opts=None):
     return ret
 
 
-def cifs_umount(mount_point):
+def cifs_umount(mount_point: str) -> int:
     """Unmount a mounted filesystem.
 
     Parameters:
@@ -51,7 +54,9 @@ def cifs_umount(mount_point):
     return ret
 
 
-def smbclient(mount_params, cmds):
+def smbclient(
+    mount_params: typing.Dict[str, str], cmds: str
+) -> typing.Tuple[int, str]:
     """Run the following command on smbclient and return the output.
 
     Parameters:

--- a/testhelper/fshelper.py
+++ b/testhelper/fshelper.py
@@ -3,7 +3,7 @@ import os
 TMP_DIR = "/tmp/"
 
 
-def get_tmp_root():
+def get_tmp_root() -> str:
     """Returns a temporary directory for use
 
     Parameters:
@@ -21,7 +21,7 @@ def get_tmp_root():
     return tmp_root
 
 
-def get_tmp_mount_point(tmp_root):
+def get_tmp_mount_point(tmp_root: str) -> str:
     """Return a mount point within the temporary directory
 
     Parameters:
@@ -39,7 +39,7 @@ def get_tmp_mount_point(tmp_root):
     return mnt_point
 
 
-def get_tmp_file(tmp_root):
+def get_tmp_file(tmp_root: str) -> str:
     """Return a temporary file within the temporary directory
 
     Parameters:
@@ -58,7 +58,7 @@ def get_tmp_file(tmp_root):
     return tmp_file
 
 
-def get_tmp_dir(tmp_root):
+def get_tmp_dir(tmp_root: str) -> str:
     """Return a temporary directory within the temporary directory
 
     Parameters:

--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -1,7 +1,8 @@
 import yaml
+import typing
 
 
-def read_yaml(file):
+def read_yaml(file: str) -> dict:
     """Returns a dict containing the contents of the yaml file.
 
     Parameters:
@@ -15,7 +16,9 @@ def read_yaml(file):
     return test_info
 
 
-def gen_mount_params(host, share, username, password):
+def gen_mount_params(
+    host: str, share: str, username: str, password: str
+) -> typing.Dict[str, str]:
     """Generate a dict of parameters required to mount a SMB share.
 
     Parameters:
@@ -36,7 +39,7 @@ def gen_mount_params(host, share, username, password):
     return ret
 
 
-def get_default_mount_params(test_info):
+def get_default_mount_params(test_info: dict) -> typing.Dict[str, str]:
     """Pass a dict of type mount_params containing the first parameters to
     mount the share.
 
@@ -54,7 +57,7 @@ def get_default_mount_params(test_info):
     )
 
 
-def get_total_mount_parameter_combinations(test_info):
+def get_total_mount_parameter_combinations(test_info: dict) -> int:
     """Get total number of combinations of mount parameters for each share.
     This is essentially "number of public  interfaces * number of test users"
 
@@ -67,7 +70,9 @@ def get_total_mount_parameter_combinations(test_info):
     return len(test_info["public_interfaces"]) * len(test_info["test_users"])
 
 
-def get_mount_parameters(test_info, share, combonum=0):
+def get_mount_parameters(
+    test_info: dict, share: str, combonum: int = 0
+) -> typing.Dict[str, str]:
     """Get the mount_params dict for a given share and given combination number
 
     Parameters:
@@ -87,7 +92,7 @@ def get_mount_parameters(test_info, share, combonum=0):
     )
 
 
-def get_num_shares(test_info):
+def get_num_shares(test_info: dict) -> int:
     """Get number of exported shares
 
     Parameters:
@@ -99,7 +104,7 @@ def get_num_shares(test_info):
     return len(test_info["exported_sharenames"])
 
 
-def get_share(test_info, share_num):
+def get_share(test_info: dict, share_num: int) -> str:
     """Get exported share name
 
     Parameters:


### PR DESCRIPTION
Allow mypy to make better static type checking by using explicit type hints. 
In order to simplify review, this PR is split into sub-topics but the logic is pretty much the same all over: whenever possible, add explicit type-hints to function arguments and return type to allow mypy (via `make check-mypy` rule) to perform its static code checks. In addition, it also improves code readability. 
