### PR TITLE
smbtorture: Use python subprocess module to execute each command

### DIFF
--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -45,33 +45,24 @@ def smbtorture(share_name: str, test: str, output: str) -> bool:
     )
 
     filter_subunit_options_str = "--fail-on-empty --prefix='samba3.'"
-    filter_subunit_filters = (
-        "--expected-failures=" + script_root + "/selftest/knownfail"
-    )
-    filter_subunit_filters = (
-        filter_subunit_filters
-        + " --expected-failures="
-        + script_root
-        + "/selftest/knownfail.d"
-    )
-    filter_subunit_filters = (
-        filter_subunit_filters
-        + " --flapping="
-        + script_root
-        + "/selftest/flapping"
-    )
-    filter_subunit_filters = (
-        filter_subunit_filters
-        + " --flapping="
-        + script_root
-        + "/selftest/flapping.d"
-    )
-    filter_subunit_filters = (
-        filter_subunit_filters
-        + " --flapping="
-        + script_root
-        + "/selftest/flapping.gluster"
-    )
+    filter_subunit_filters = ""
+    for filter in ["knownfail", "knownfail.d"]:
+        filter_subunit_filters = (
+            filter_subunit_filters
+            + " --expected-failures="
+            + script_root
+            + "/selftest/"
+            + filter
+        )
+    for filter in ["flapping", "flapping.d", "flapping.gluster"]:
+        filter_subunit_filters = (
+            filter_subunit_filters
+            + " --flapping="
+            + script_root
+            + "/selftest/"
+            + filter
+        )
+
     filter_subunit_cmd = "%s %s %s" % (
         filter_subunit_exec,
         filter_subunit_options_str,


### PR DESCRIPTION
This is a clean up of the smbtorture test script. 

To run out smbtorture tests, we need to execute smbtorture and pipe it through the filter-subunit and format-subunit commands to return test results. The resulting command string generated is unwieldy.

We clean up the smbtorture tests by using the python subprocess module to pipe the output of each individual command and hopefully make it easier to maintain.
