### PR TITLE
mount: test I/O sanity

### DIFF
--- a/testcases/mount/mount_io.py
+++ b/testcases/mount/mount_io.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+# Test various file-system I/O operations via local SMB mount-point.
+
+import datetime
+import pathlib
+import random
+import shutil
+import typing
+
+
+class DataPath:
+    """A pair of random data-buffer and path-name to its regular file"""
+
+    def __init__(self, path: pathlib.Path, size: int) -> None:
+        self.path = path
+        self.size = size
+        self.data = _generate_random_bytes(size)
+
+    def renew(self) -> None:
+        self.data = _generate_random_bytes(self.size)
+
+    def write(self) -> None:
+        self.path.write_bytes(self.data)
+
+    def overwrite(self) -> None:
+        self.renew()
+        self.write()
+
+    def read(self) -> bytes:
+        return self.path.read_bytes()
+
+    def mkdirs(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def unlink(self) -> None:
+        self.path.unlink()
+
+    def stat_size(self) -> int:
+        return self.path.stat().st_size
+
+    def verify(self) -> None:
+        self.verify_size()
+        self.verify_data()
+
+    def verify_size(self) -> None:
+        st_size = self.stat_size()
+        if st_size != self.size:
+            raise IOError(
+                f"stat size mismatch: {st_size} != {self.size} {self.path}"
+            )
+
+    def verify_data(self) -> None:
+        data = self.read()
+        dlen = len(data)
+        if dlen != self.size:
+            raise IOError(f"data length mismatch: {dlen} != {self.size}")
+        if data != self.data:
+            raise IOError(f"data mismatch at {self.path}")
+
+    def verify_noent(self) -> None:
+        has_stat = False
+        try:
+            self.path.stat()
+            has_stat = True
+        except FileNotFoundError:
+            pass
+        if has_stat:
+            raise IOError(f"still exists: {self.path}")
+
+
+def _make_pathname(base: pathlib.Path, idx: int) -> pathlib.Path:
+    return base / str(idx)
+
+
+def _make_datapath(base: pathlib.Path, idx: int, size: int) -> DataPath:
+    return DataPath(_make_pathname(base, idx), size)
+
+
+def _make_datasets(
+    base: pathlib.Path, size: int, count: int
+) -> typing.List[DataPath]:
+    return [_make_datapath(base, idx, size) for idx in range(0, count)]
+
+
+def _run_checks(dsets: typing.List[DataPath]) -> None:
+    for dset in dsets:
+        dset.mkdirs()
+    for dset in dsets:
+        dset.write()
+    for dset in dsets:
+        dset.verify()
+    for dset in dsets:
+        dset.overwrite()
+    for dset in dsets:
+        dset.verify()
+    for dset in dsets:
+        dset.unlink()
+    for dset in dsets:
+        dset.verify_noent()
+
+
+def _check_io_consistency(rootdir: str) -> None:
+    base = None
+    try:
+        print("\n")
+        base = pathlib.Path(rootdir) / "test_io_consistency"
+        base.mkdir(parents=True)
+        # Case-1: single 4K file
+        _run_checks(_make_datasets(base, 4096, 1))
+        # Case-2: single 16M file
+        _run_checks(_make_datasets(base, 2**24, 1))
+        # Case-3: few 1M files
+        _run_checks(_make_datasets(base, 2**20, 10))
+        # Case-4: many 1K files
+        _run_checks(_make_datasets(base, 1024, 100))
+    except Exception as ex:
+        print("Error while executing test_io_consistency: %s", ex)
+        raise
+    finally:
+        if base:
+            shutil.rmtree(base, ignore_errors=True)
+
+
+def _generate_random_bytes(size: int) -> bytes:
+    """
+    Creates bytes-sequence filled with random values.
+
+    In order to avoid exhausting random pool (which causes high CPU usage)
+    re-use the first page of current random buffer to re-construct larger
+    one, thus creating only "pseudo" random bytes instead of true random.
+
+    Needed because random.randbytes() is available only in Python>=3.9.
+    """
+    rbytes = bytearray(0)
+    while len(rbytes) < size:
+        rnd = random.randint(0, 0xFFFFFFFFFFFFFFFF)
+        rba = bytearray(rnd.to_bytes(8, "big"))
+        if len(rbytes) < 4096:
+            rbytes = rbytes + rba
+        else:
+            rbytes = rba + rbytes + rba + rbytes
+    return rbytes[:size]
+
+
+def _reset_random_seed() -> None:
+    now = datetime.datetime.now()
+    seed = int(now.year * now.day * now.hour * now.minute / (now.second + 1))
+    random.seed(seed)
+
+
+def check_io_consistency(rootdir: str) -> None:
+    _reset_random_seed()
+    _check_io_consistency(rootdir)

--- a/testcases/mount/test_mount.py
+++ b/testcases/mount/test_mount.py
@@ -11,8 +11,6 @@ import typing
 
 from .mount_io import check_io_consistency
 
-test_string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-
 # Use a global test_info to get a better output when running pytest
 test_info: typing.Dict[str, typing.Any] = {}
 
@@ -26,13 +24,8 @@ def mount_check(ipaddr: str, share_name: str) -> None:
     try:
         testhelper.cifs_mount(mount_params, mount_point)
         flag_mounted = True
-        test_file = testhelper.get_tmp_file(mount_point)
-        with open(test_file, "w") as f:
-            f.write(test_string)
         check_io_consistency(mount_point)
     finally:
-        if os.path.exists(test_file):
-            os.unlink(test_file)
         if flag_mounted:
             testhelper.cifs_umount(mount_point)
         os.rmdir(mount_point)

--- a/testcases/mount/test_mount.py
+++ b/testcases/mount/test_mount.py
@@ -9,6 +9,8 @@ import sys
 import pytest
 import typing
 
+from .mount_io import check_io_consistency
+
 test_string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 # Use a global test_info to get a better output when running pytest
@@ -27,6 +29,7 @@ def mount_check(ipaddr: str, share_name: str) -> None:
         test_file = testhelper.get_tmp_file(mount_point)
         with open(test_file, "w") as f:
             f.write(test_string)
+        check_io_consistency(mount_point)
     finally:
         if os.path.exists(test_file):
             os.unlink(test_file)


### PR DESCRIPTION
Add extra I/O checks to mounted SMB share, using different files sizes and number-of-file per directory:

 - Write-read + data consistency check.
 - Overwrite-read + data consistency check.
 - Stat + size check
 - Unlink

Using Pyhton's pathlib over local mount-point.