### PR TITLE
CI: Enable testing with multiple python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,13 +5,16 @@ jobs:
   check:
     name: Run python code checkers
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Update
         run: sudo apt-get update
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: python -m pip install tox
       - name: Check code with flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = flake8, black, mypy, py39
+envlist = flake8, black, mypy, py39, py310, py311
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This change ensures that we focus to stay compatible with three most recent python versions and helps in making the codebase more robust.