### PR TITLE
smbtorture: remove smb2.replay from the executable tests

### DIFF
--- a/testcases/smbtorture/smbtorture-tests-info.yml
+++ b/testcases/smbtorture/smbtorture-tests-info.yml
@@ -15,8 +15,6 @@
 #- smb2.multichannel
 - smb2.notify-inotify
 - smb2.rename
-# https://github.com/gluster/samba-integration/issues/187
-#- smb2.replay
 - smb2.sdread
 - smb2.secleak
 - smb2.session-id


### PR DESCRIPTION
These tests are not best testing the samba protocol but they are
tweaks around some possible bug in windows which is not yet resolved:
https://lists.samba.org/archive/cifs-protocol/2021-May/003550.html
Also these are still part of known failures:
https://gitlab.com/samba-team/samba/-/commit/f5168a21abd029fd57edfd270b86512312c801b1

Hence removing them from this testsuit to remove unnecessary chatter.