### PR TITLE
pytest with randomly via tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.tox
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ define runtox
 	@cd "$(ROOT_DIR)" && tox -e $1
 endef
 
+.PHONY: test
 test:
-	@pytest -v `cat testcases/tests|sed 's/^/testcases\//'`
+	$(call runtox, "pytest")
 
+.PHONY: sanity_test
 sanity_test:
-	@pytest -v testcases/consistency
-
-.PHONY: test sanity_test
+	$(call runtox, "sanity")
 
 .PHONY: check-mypy
 check-mypy:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,28 @@
 
 [tox]
-envlist = flake8, black, mypy, py39, py310, py311
+envlist = pytest, sanity, flake8, black, mypy, py39, py310, py311
 isolated_build = True
 
 [testenv]
 minversion = 3.9
+passenv =
+  TEST_INFO_FILE
 deps = pytest
 commands = py.test -v .
+
+[testenv:pytest]
+deps =
+  pytest
+  pyyaml
+  pytest-randomly
+commands = pytest -v testcases/mount testcases/consistency testcases/smbtorture
+
+[testenv:sanity]
+deps =
+  pytest
+  pyyaml
+  pytest-randomly
+commands = pytest -v testcases/consistency
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Use tox to run pytest. Use pytest-randomly to have better control on random seed upon re-run due to test failure.