### PR TITLE
tox.ini cleanups

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ isolated_build = True
 minversion = 3.9
 passenv =
   TEST_INFO_FILE
+  PYTHONPATH
 deps = pytest
 commands = py.test -v .
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,23 +6,23 @@ isolated_build = True
 [testenv]
 minversion = 3.9
 passenv =
-  TEST_INFO_FILE
-  PYTHONPATH
+    TEST_INFO_FILE
+    PYTHONPATH
 deps = pytest
 commands = py.test -v .
 
 [testenv:pytest]
 deps =
-  pytest
-  pyyaml
-  pytest-randomly
+    pytest
+    pyyaml
+    pytest-randomly
 commands = pytest -v testcases/mount testcases/consistency testcases/smbtorture
 
 [testenv:sanity]
 deps =
-  pytest
-  pyyaml
-  pytest-randomly
+    pytest
+    pyyaml
+    pytest-randomly
 changedir = {toxinidir}
 commands = pytest -v testcases/consistency
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,14 +23,17 @@ deps =
   pytest
   pyyaml
   pytest-randomly
+changedir = {toxinidir}
 commands = pytest -v testcases/consistency
 
 [testenv:flake8]
 deps = flake8
+changedir = {toxinidir}
 commands = flake8 .
 
 [testenv:black]
 deps = black>=23.3.0
+changedir = {toxinidir}
 commands = black --check -l 79 -v .
 
 [testenv:mypy]
@@ -40,4 +43,5 @@ deps =
     types-setuptools
     types-pyyaml
     types-python-dateutil
+changedir = {toxinidir}
 commands = mypy --no-color-output .


### PR DESCRIPTION
Few minor cleanups to top-level `tox.ini`. Plus, passenv PYTHONPATH.