### PR TITLE
Allow test with already-mounted smbshare on local dir

### DIFF
--- a/testcases/mount/test_mount.py
+++ b/testcases/mount/test_mount.py
@@ -16,6 +16,11 @@ test_info = os.getenv("TEST_INFO_FILE")
 test_info_dict = testhelper.read_yaml(test_info)
 
 
+def _check_mounted_smbshare(test_dir: str) -> None:
+    check_io_consistency(test_dir)
+    check_dbm_consistency(test_dir)
+
+
 def mount_check(ipaddr: str, share_name: str) -> None:
     mount_params = testhelper.get_mount_parameters(test_info_dict, share_name)
     mount_params["host"] = ipaddr
@@ -27,8 +32,7 @@ def mount_check(ipaddr: str, share_name: str) -> None:
         flag_mounted = True
         test_dir = os.path.join(mount_point, "mount_test")
         os.mkdir(test_dir)
-        check_io_consistency(test_dir)
-        check_dbm_consistency(test_dir)
+        _check_mounted_smbshare(test_dir)
     finally:
         if flag_mounted:
             shutil.rmtree(test_dir, ignore_errors=True)

--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -18,7 +18,11 @@ def read_yaml(test_info):
 
 
 def gen_mount_params(
-    host: str, share: str, username: str, password: str
+    host: str,
+    share: str,
+    username: str,
+    password: str,
+    test_dir: str = "",
 ) -> typing.Dict[str, str]:
     """Generate a dict of parameters required to mount a SMB share.
 
@@ -27,6 +31,7 @@ def gen_mount_params(
     share: exported share name
     username: username
     password: password for the user
+    test_dir: (optional) local-host test-dir over a mounted share
 
     Returns:
     dict: mount parameters in a dict
@@ -36,6 +41,7 @@ def gen_mount_params(
         "share": share,
         "username": username,
         "password": password,
+        "test_dir": test_dir,
     }
     return ret
 
@@ -90,6 +96,7 @@ def get_mount_parameters(
         share,
         test_info["test_users"][num_users]["username"],
         test_info["test_users"][num_users]["password"],
+        test_info.get("test_dir", ""),
     )
 
 


### PR DESCRIPTION
When running over Windows, we should not execute the cifs_mount/cifs_umount helper functions. Instead, allow running mount tests over already existing smbshare directory, which the user attached via PowerShell's `net use` command.