### PR TITLE
smbtorture: return None from test_smbtorture

### DIFF
--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -134,13 +134,12 @@ def generate_smbtorture_tests(
 @pytest.mark.parametrize(
     "share_name,test", generate_smbtorture_tests(os.getenv("TEST_INFO_FILE"))
 )
-def test_smbtorture(share_name: str, test: str) -> bool:
+def test_smbtorture(share_name: str, test: str) -> None:
     ret = smbtorture(share_name, test, output)
     if os.path.exists(output):
         os.unlink(output)
     if not ret:
         pytest.fail("Failure in running test - %s" % (test), pytrace=False)
-    return True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Newer pytest expects test entry-point functions to return None. On CI machines (with CentOS9-stream and Python-3.9) it also yields a warn messages.