### PR TITLE
testcases: simplify test structure

### DIFF
--- a/testcases/consistency/test_consistency.py
+++ b/testcases/consistency/test_consistency.py
@@ -8,7 +8,6 @@
 
 import testhelper
 import os
-import sys
 import pytest
 import typing
 
@@ -77,20 +76,5 @@ def test_consistency(ipaddr: str, share_name: str) -> None:
     tmp_root = testhelper.get_tmp_root()
     mount_point = testhelper.get_tmp_mount_point(tmp_root)
     consistency_check(mount_point, ipaddr, share_name)
-    os.rmdir(mount_point)
-    os.rmdir(tmp_root)
-
-
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: %s <test-info.yml>" % (sys.argv[0]))
-        exit(1)
-    test_info_file = sys.argv[1]
-    tmp_root = testhelper.get_tmp_root()
-    mount_point = testhelper.get_tmp_mount_point(tmp_root)
-    print("Running consistency check:")
-    for ipaddr, share_name in generate_consistency_check(test_info_file):
-        print("%s - %s" % (ipaddr, share_name))
-        consistency_check(mount_point, ipaddr, share_name)
     os.rmdir(mount_point)
     os.rmdir(tmp_root)

--- a/testcases/mount/test_mount.py
+++ b/testcases/mount/test_mount.py
@@ -5,7 +5,6 @@
 
 import testhelper
 import os
-import sys
 import pytest
 import typing
 import shutil
@@ -57,14 +56,3 @@ def generate_mount_check(
 )
 def test_mount(ipaddr: str, share_name: str) -> None:
     mount_check(ipaddr, share_name)
-
-
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: %s <test-info.yml>" % (sys.argv[0]))
-        exit(1)
-    test_info_file = sys.argv[1]
-    print("Running mount check:")
-    for ipaddr, share_name in generate_mount_check(test_info_file):
-        print("%s - %s" % (ipaddr, share_name))
-        mount_check(ipaddr, share_name)

--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -15,14 +15,16 @@ filter_subunit_exec = script_root + "/selftest/filter-subunit"
 format_subunit_exec = script_root + "/selftest/format-subunit"
 smbtorture_tests_file = script_root + "/smbtorture-tests-info.yml"
 
-test_info: typing.Dict[str, typing.Any] = {}
+test_info = os.getenv("TEST_INFO_FILE")
+test_info_dict = testhelper.read_yaml(test_info)
+
 # Temp filename containing the output of run commands.
 output = testhelper.get_tmp_file("/tmp")
 
 
 def smbtorture(share_name: str, test: str, tmp_output: str) -> bool:
     # build smbtorture command
-    mount_params = testhelper.get_mount_parameters(test_info, share_name)
+    mount_params = testhelper.get_mount_parameters(test_info_dict, share_name)
     smbtorture_cmd = [
         smbtorture_exec,
         "--fullname",
@@ -48,7 +50,7 @@ def smbtorture(share_name: str, test: str, tmp_output: str) -> bool:
             "--expected-failures=" + script_root + "/selftest/" + filter
         )
     flapping_list = ["flapping", "flapping.d"]
-    test_backend = test_info.get("test_backend")
+    test_backend = test_info_dict.get("test_backend")
     if test_backend is not None:
         flapping_file = "flapping." + test_backend
         flapping_file_path = os.path.join(
@@ -114,25 +116,17 @@ def list_smbtorture_tests():
     return smbtorture_info
 
 
-def generate_smbtorture_tests(
-    test_info_file: typing.Optional[str],
-) -> typing.List[typing.Tuple[str, str]]:
-    global test_info
-    if not test_info_file:
-        return []
-    test_info = testhelper.read_yaml(test_info_file)
+def generate_smbtorture_tests() -> typing.List[typing.Tuple[str, str]]:
     smbtorture_info = list_smbtorture_tests()
     arr = []
-    for sharenum in range(testhelper.get_num_shares(test_info)):
-        share_name = testhelper.get_share(test_info, sharenum)
+    for sharenum in range(testhelper.get_num_shares(test_info_dict)):
+        share_name = testhelper.get_share(test_info_dict, sharenum)
         for torture_test in smbtorture_info:
             arr.append((share_name, torture_test))
     return arr
 
 
-@pytest.mark.parametrize(
-    "share_name,test", generate_smbtorture_tests(os.getenv("TEST_INFO_FILE"))
-)
+@pytest.mark.parametrize("share_name,test", generate_smbtorture_tests())
 def test_smbtorture(share_name: str, test: str) -> None:
     ret = smbtorture(share_name, test, output)
     if os.path.exists(output):

--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -3,7 +3,6 @@
 # Run smbtorture tests
 
 import testhelper
-import sys
 import os
 import yaml
 import pytest
@@ -140,15 +139,3 @@ def test_smbtorture(share_name: str, test: str) -> None:
         os.unlink(output)
     if not ret:
         pytest.fail("Failure in running test - %s" % (test), pytrace=False)
-
-
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: %s <test-info.yml>" % (sys.argv[0]))
-        exit(1)
-
-    test_info_file = sys.argv[1]
-    print("Running smbtorture test:")
-    for share_name, test in generate_smbtorture_tests(test_info_file):
-        print(share_name + " - " + test)
-        test_smbtorture(share_name, test)

--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -3,16 +3,16 @@ import typing
 import random
 
 
-def read_yaml(file: str) -> dict:
+def read_yaml(test_info):
     """Returns a dict containing the contents of the yaml file.
 
     Parameters:
-    arg1: filename of yaml file
+    test_info: filename of yaml file.
 
     Returns:
-    dict: parsed contents of a yaml file
+    dict: The parsed test information yml as a dictionary.
     """
-    with open(file) as f:
+    with open(test_info) as f:
         test_info = yaml.load(f, Loader=yaml.FullLoader)
     return test_info
 
@@ -81,7 +81,7 @@ def get_mount_parameters(
     share: The share for which to get the mount_params
     combonum: The combination number to use.
     """
-    if combonum > get_total_mount_parameter_combinations(test_info):
+    if combonum >= get_total_mount_parameter_combinations(test_info):
         assert False, "Invalid combination number"
     num_public = int(combonum / len(test_info["test_users"]))
     num_users = combonum % len(test_info["test_users"])
@@ -113,7 +113,7 @@ def get_share(test_info: dict, share_num: int) -> str:
     share_num: The index within the exported sharenames list
 
     Returns:
-    str: exported sharename in index share_num
+    str: exported sharename at index share_num
     """
     return test_info["exported_sharenames"][share_num]
 


### PR DESCRIPTION
pytest by default runs the functions preceeded with test keyword. As a result, all the required test functions will be executed. Hence, this PR simplifies the code by removing the unnecessary main block.