### PR TITLE
smbtorture/selftest: Add flapping.cephfs

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs
@@ -1,0 +1,2 @@
+# https://github.com/samba-in-kubernetes/sit-test-cases/issues/35
+^samba3.smb2.rw.invalid


### PR DESCRIPTION
We have identified at least one sub test which we wish to skip the result rather than modifying the server each time for specific use cases. Therefore start with a dedicated flapping file for CephFS.

fixes #35 