### PR TITLE
Use os.path.join method instead of string concatination

### DIFF
--- a/testcases/mount/test_mount.py
+++ b/testcases/mount/test_mount.py
@@ -25,7 +25,7 @@ def mount_check(ipaddr: str, share_name: str) -> None:
     try:
         testhelper.cifs_mount(mount_params, mount_point)
         flag_mounted = True
-        test_dir = mount_point + "/mount_test"
+        test_dir = os.path.join(mount_point, "mount_test")
         os.mkdir(test_dir)
         check_io_consistency(test_dir)
         check_dbm_consistency(test_dir)


### PR DESCRIPTION
As the seperator('/\') can vary from OS to OS, it is best practice to use os.path.join method instead of string concatination.

This change makes the code platform independent.