### PR TITLE
Cleanup testhelper and add pathlib.Path to helper functions.

### DIFF
--- a/testcases/containers/test_containers.py
+++ b/testcases/containers/test_containers.py
@@ -54,13 +54,13 @@ def containers_check_mounted(mount_point: Path, test: str) -> None:
 def containers_check(ipaddr: str, share_name: str, test: str) -> None:
     mount_params = testhelper.get_mount_parameters(test_info, share_name)
     mount_params["host"] = ipaddr
-    tmp_root = Path(testhelper.get_tmp_root())
-    mount_point = Path(testhelper.get_tmp_mount_point(str(tmp_root)))
-    testhelper.cifs_mount(mount_params, str(mount_point))
+    tmp_root = testhelper.get_tmp_root()
+    mount_point = testhelper.get_tmp_mount_point(tmp_root)
+    testhelper.cifs_mount(mount_params, mount_point)
     try:
         containers_check_mounted(mount_point, test)
     finally:
-        testhelper.cifs_umount(str(mount_point))
+        testhelper.cifs_umount(mount_point)
         mount_point.rmdir()
         tmp_root.rmdir()
 

--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -15,8 +15,8 @@ filter_subunit_exec = script_root + "/selftest/filter-subunit"
 format_subunit_exec = script_root + "/selftest/format-subunit"
 smbtorture_tests_file = script_root + "/smbtorture-tests-info.yml"
 
-test_info = os.getenv("TEST_INFO_FILE")
-test_info_dict = testhelper.read_yaml(test_info)
+test_info_file = os.getenv("TEST_INFO_FILE")
+test_info = testhelper.read_yaml(test_info_file)
 
 # Temp filename containing the output of run commands.
 output = testhelper.get_tmp_file("/tmp")
@@ -24,7 +24,7 @@ output = testhelper.get_tmp_file("/tmp")
 
 def smbtorture(share_name: str, test: str, tmp_output: str) -> bool:
     # build smbtorture command
-    mount_params = testhelper.get_mount_parameters(test_info_dict, share_name)
+    mount_params = testhelper.get_mount_parameters(test_info, share_name)
     smbtorture_cmd = [
         smbtorture_exec,
         "--fullname",
@@ -50,7 +50,7 @@ def smbtorture(share_name: str, test: str, tmp_output: str) -> bool:
             "--expected-failures=" + script_root + "/selftest/" + filter
         )
     flapping_list = ["flapping", "flapping.d"]
-    test_backend = test_info_dict.get("test_backend")
+    test_backend = test_info.get("test_backend")
     if test_backend is not None:
         flapping_file = "flapping." + test_backend
         flapping_file_path = os.path.join(
@@ -119,8 +119,7 @@ def list_smbtorture_tests():
 def generate_smbtorture_tests() -> typing.List[typing.Tuple[str, str]]:
     smbtorture_info = list_smbtorture_tests()
     arr = []
-    for sharenum in range(testhelper.get_num_shares(test_info_dict)):
-        share_name = testhelper.get_share(test_info_dict, sharenum)
+    for share_name in test_info.get("exported_sharenames", []):
         for torture_test in smbtorture_info:
             arr.append((share_name, torture_test))
     return arr

--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -20,7 +20,7 @@ test_info_file = os.getenv("TEST_INFO_FILE")
 test_info = testhelper.read_yaml(test_info_file)
 
 # Temp filename containing the output of run commands.
-output = testhelper.get_tmp_file(Path("/tmp"))
+output = testhelper.get_tmp_file()
 
 
 def smbtorture(share_name: str, test: str, tmp_output: Path) -> bool:

--- a/testcases/smbtorture/test_smbtorture.py
+++ b/testcases/smbtorture/test_smbtorture.py
@@ -8,6 +8,7 @@ import yaml
 import pytest
 import typing
 import subprocess
+from pathlib import Path
 
 script_root = os.path.dirname(os.path.realpath(__file__))
 smbtorture_exec = "/bin/smbtorture"
@@ -19,10 +20,10 @@ test_info_file = os.getenv("TEST_INFO_FILE")
 test_info = testhelper.read_yaml(test_info_file)
 
 # Temp filename containing the output of run commands.
-output = testhelper.get_tmp_file("/tmp")
+output = testhelper.get_tmp_file(Path("/tmp"))
 
 
-def smbtorture(share_name: str, test: str, tmp_output: str) -> bool:
+def smbtorture(share_name: str, test: str, tmp_output: Path) -> bool:
     # build smbtorture command
     mount_params = testhelper.get_mount_parameters(test_info, share_name)
     smbtorture_cmd = [

--- a/testhelper/cmdhelper.py
+++ b/testhelper/cmdhelper.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 def cifs_mount(
-    mount_params: typing.Dict[str, str], mount_point: str, opts: str = ""
+    mount_params: typing.Dict[str, str], mount_point: Path, opts: str = ""
 ) -> int:
     """Use the cifs module to mount a share.
 
@@ -35,13 +35,20 @@ def cifs_mount(
             + mount_params["password"]
         )
     share = "//" + mount_params["host"] + "/" + mount_params["share"]
-    cmd = "mount -t cifs -o " + mount_options + " " + share + " " + mount_point
+    cmd = (
+        "mount -t cifs -o "
+        + mount_options
+        + " "
+        + share
+        + " "
+        + str(mount_point)
+    )
     ret = os.system(cmd)
     assert ret == 0, "Error mounting: ret %d cmd: %s\n" % (ret, cmd)
     return ret
 
 
-def cifs_umount(mount_point: str) -> int:
+def cifs_umount(mount_point: Path) -> int:
     """Unmount a mounted filesystem.
 
     Parameters:

--- a/testhelper/fshelper.py
+++ b/testhelper/fshelper.py
@@ -1,28 +1,29 @@
 import os
+from pathlib import Path
 
-TMP_DIR = "/tmp/"
 
-
-def get_tmp_root() -> str:
-    """Returns a temporary directory for use
+def get_tmp_root(tmp_dir: Path = Path("/tmp")) -> Path:
+    """
+    Returns a temporary directory for use
 
     Parameters:
-    none
+    tmp_dir: Temporary location to use. Set to "/tmp" by default
 
     Returns:
     tmp_root: Location of the temporary directory.
     """
-    tmp_root = TMP_DIR + "/" + str(os.getpid())
+    tmp_root = tmp_dir / str(os.getpid())
     i = 0
-    while os.path.exists(tmp_root):
-        tmp_root = tmp_root + str(i)
+    while tmp_root.exists():
+        tmp_root = tmp_root / str(i)
         i = i + 1
-    os.mkdir(tmp_root)
+    tmp_root.mkdir()
     return tmp_root
 
 
-def get_tmp_mount_point(tmp_root: str) -> str:
-    """Return a mount point within the temporary directory
+def get_tmp_mount_point(tmp_root: Path) -> Path:
+    """
+    Return a mount point within the temporary directory
 
     Parameters:
     tmp_root: Directory in which to create mount point.
@@ -31,16 +32,17 @@ def get_tmp_mount_point(tmp_root: str) -> str:
     mnt_point: Directory location in which you can mount a share.
     """
     i = 0
-    mnt_point = tmp_root + "/mnt_" + str(i)
-    while os.path.exists(mnt_point):
+    mnt_point = tmp_root / str("mnt_" + str(i))
+    while mnt_point.exists():
         i = i + 1
-        mnt_point = tmp_root + "/" + str(i)
-    os.mkdir(mnt_point)
+        mnt_point = tmp_root / str("mnt_" + str(i))
+    mnt_point.mkdir()
     return mnt_point
 
 
-def get_tmp_file(tmp_root: str) -> str:
-    """Return a temporary file within the temporary directory
+def get_tmp_file(tmp_root: Path) -> Path:
+    """
+    Return a temporary file within the temporary directory
 
     Parameters:
     tmp_root: Directory in which to create temporary file.
@@ -49,17 +51,17 @@ def get_tmp_file(tmp_root: str) -> str:
     tmp_file: Location of temporary file.
     """
     i = 0
-    tmp_file = tmp_root + "/tmp_file_" + str(i)
-    while os.path.exists(tmp_file):
+    tmp_file = tmp_root / str("tmp_file_" + str(i))
+    while tmp_file.exists():
         i = i + 1
-        tmp_file = tmp_root + "/tmp_file_" + str(i)
-    f = open(tmp_file, "w")
-    f.close()
+        tmp_file = tmp_root / str("tmp_file_" + str(i))
+    tmp_file.touch()
     return tmp_file
 
 
-def get_tmp_dir(tmp_root: str) -> str:
-    """Return a temporary directory within the temporary directory
+def get_tmp_dir(tmp_root: Path) -> Path:
+    """
+    Return a temporary directory within the temporary directory
 
     Parameters:
     tmp_root: Directory in which to create temporary directory.
@@ -68,9 +70,9 @@ def get_tmp_dir(tmp_root: str) -> str:
     tmp_dir: Location of temporary directory.
     """
     i = 0
-    tmp_dir = tmp_root + "/tmp_dir_" + str(i)
-    while os.path.exists(tmp_dir):
+    tmp_dir = tmp_root / str("tmp_dir_" + str(i))
+    while tmp_dir.exists():
         i = i + 1
-        tmp_dir = tmp_root + "/tmp_dir_" + str(i)
-        os.mkdir(tmp_dir)
+        tmp_dir = tmp_root / str("tmp_dir_" + str(i))
+        tmp_dir.mkdir()
     return tmp_dir

--- a/testhelper/fshelper.py
+++ b/testhelper/fshelper.py
@@ -1,8 +1,9 @@
 import os
+import tempfile
 from pathlib import Path
 
 
-def get_tmp_root(tmp_dir: Path = Path("/tmp")) -> Path:
+def get_tmp_root() -> Path:
     """
     Returns a temporary directory for use
 
@@ -12,16 +13,10 @@ def get_tmp_root(tmp_dir: Path = Path("/tmp")) -> Path:
     Returns:
     tmp_root: Location of the temporary directory.
     """
-    tmp_root = tmp_dir / str(os.getpid())
-    i = 0
-    while tmp_root.exists():
-        tmp_root = tmp_root / str(i)
-        i = i + 1
-    tmp_root.mkdir()
-    return tmp_root
+    return Path(tempfile.mkdtemp())
 
 
-def get_tmp_mount_point(tmp_root: Path) -> Path:
+def get_tmp_mount_point(tmp_root: Path = Path(tempfile.gettempdir())) -> Path:
     """
     Return a mount point within the temporary directory
 
@@ -31,16 +26,10 @@ def get_tmp_mount_point(tmp_root: Path) -> Path:
     Returns:
     mnt_point: Directory location in which you can mount a share.
     """
-    i = 0
-    mnt_point = tmp_root / str("mnt_" + str(i))
-    while mnt_point.exists():
-        i = i + 1
-        mnt_point = tmp_root / str("mnt_" + str(i))
-    mnt_point.mkdir()
-    return mnt_point
+    return Path(tempfile.mkdtemp(prefix="mnt_", dir=tmp_root))
 
 
-def get_tmp_file(tmp_root: Path) -> Path:
+def get_tmp_file(tmp_root: Path = Path(tempfile.gettempdir())) -> Path:
     """
     Return a temporary file within the temporary directory
 
@@ -50,16 +39,12 @@ def get_tmp_file(tmp_root: Path) -> Path:
     Returns:
     tmp_file: Location of temporary file.
     """
-    i = 0
-    tmp_file = tmp_root / str("tmp_file_" + str(i))
-    while tmp_file.exists():
-        i = i + 1
-        tmp_file = tmp_root / str("tmp_file_" + str(i))
-    tmp_file.touch()
-    return tmp_file
+    (fd, file_name) = tempfile.mkstemp(dir=tmp_root)
+    os.close(fd)
+    return Path(file_name)
 
 
-def get_tmp_dir(tmp_root: Path) -> Path:
+def get_tmp_dir(tmp_root: Path = Path(tempfile.gettempdir())) -> Path:
     """
     Return a temporary directory within the temporary directory
 
@@ -69,10 +54,4 @@ def get_tmp_dir(tmp_root: Path) -> Path:
     Returns:
     tmp_dir: Location of temporary directory.
     """
-    i = 0
-    tmp_dir = tmp_root / str("tmp_dir_" + str(i))
-    while tmp_dir.exists():
-        i = i + 1
-        tmp_dir = tmp_root / str("tmp_dir_" + str(i))
-        tmp_dir.mkdir()
-    return tmp_dir
+    return Path(tempfile.mkdtemp(dir=tmp_root))

--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -41,82 +41,19 @@ def gen_mount_params(
     return ret
 
 
-def get_default_mount_params(test_info: dict) -> typing.Dict[str, str]:
-    """Pass a dict of type mount_params containing the first parameters to
-    mount the share.
-
-    Parameters:
-    test_info: Dict containing the parsed yaml file.
-
-    Returns:
-    Dict: of type mount_params containing the parameters to mount the share.
-    """
-    return gen_mount_params(
-        test_info["public_interfaces"][0],
-        test_info["exported_sharenames"][0],
-        test_info["test_users"][0]["username"],
-        test_info["test_users"][0]["password"],
-    )
-
-
-def get_total_mount_parameter_combinations(test_info: dict) -> int:
-    """Get total number of combinations of mount parameters for each share.
-    This is essentially "number of public  interfaces * number of test users"
-
-    Parameters:
-    test_info: Dict containing the parsed yaml file.
-
-    Returns:
-    int: number of possible combinations.
-    """
-    return len(test_info["public_interfaces"]) * len(test_info["test_users"])
-
-
-def get_mount_parameters(
-    test_info: dict, share: str, combonum: int = 0
-) -> typing.Dict[str, str]:
-    """Get the mount_params dict for a given share and given combination number
+def get_mount_parameters(test_info: dict, share: str) -> typing.Dict[str, str]:
+    """Get the default mount_params dict for a given share
 
     Parameters:
     test_info: Dict containing the parsed yaml file.
     share: The share for which to get the mount_params
-    combonum: The combination number to use.
     """
-    if combonum >= get_total_mount_parameter_combinations(test_info):
-        assert False, "Invalid combination number"
-    num_public = int(combonum / len(test_info["test_users"]))
-    num_users = combonum % len(test_info["test_users"])
     return gen_mount_params(
-        test_info["public_interfaces"][num_public],
+        test_info["public_interfaces"][0],
         share,
-        test_info["test_users"][num_users]["username"],
-        test_info["test_users"][num_users]["password"],
+        test_info["test_users"][0]["username"],
+        test_info["test_users"][0]["password"],
     )
-
-
-def get_num_shares(test_info: dict) -> int:
-    """Get number of exported shares
-
-    Parameters:
-    test_info: Dict containing the parsed yml file.
-
-    Returns:
-    int: number of exported shares
-    """
-    return len(test_info["exported_sharenames"])
-
-
-def get_share(test_info: dict, share_num: int) -> str:
-    """Get exported share name
-
-    Parameters:
-    test_info: Dict containing the parsed yml file.
-    share_num: The index within the exported sharenames list
-
-    Returns:
-    str: exported sharename at index share_num
-    """
-    return test_info["exported_sharenames"][share_num]
 
 
 def generate_random_bytes(size: int) -> bytes:


### PR DESCRIPTION
Several functions are no longer needed after refactoring of some tests.

Also use pathlib.Path so that tests can be used with windows.


depends on #41 