### PR TITLE
testcases: containerized subset of LTP test-suits over SMB-share

### DIFF
--- a/testcases/containers/images/ltp/Containerfile
+++ b/testcases/containers/images/ltp/Containerfile
@@ -1,0 +1,25 @@
+#Version: 0.0.1
+FROM quay.io/centos/centos:stream9 as builder
+WORKDIR /sit
+RUN dnf install -y dnf-plugin-config-manager epel-release epel-next-release
+RUN dnf config-manager --set-enabled crb
+RUN dnf install -y \
+  automake gcc git libaio-devel libattr-devel libcap-devel libcurl-devel \
+  libtool libunwind-devel libuuid-devel lz4 lz4-devel make openssl-devel \
+  perl-core perl-libwww-perl zlib zlib-devel
+RUN git clone https://github.com/linux-test-project/ltp
+WORKDIR /sit/ltp
+RUN make autotools
+RUN ./configure --disable-metadata --prefix="/sit/ltp/ltproot"
+RUN make
+RUN make install
+
+FROM quay.io/centos/centos:stream9
+ENV REFRESHED_AT 2023-11-13-01
+WORKDIR /
+RUN dnf install -y libaio lz4 libuuid
+COPY --from=builder /sit/ltp/ltproot /opt/ltp
+COPY run_ltp.sh ./
+RUN install -m 00775 ./run_ltp.sh /bin
+CMD ["/bin/run_ltp.sh"]
+

--- a/testcases/containers/images/ltp/Makefile
+++ b/testcases/containers/images/ltp/Makefile
@@ -1,0 +1,15 @@
+CONTAINER_CMD ?= podman
+IMG_PREFIX := quay.io/samba.org/sit-test-cases
+IMG_TAG := ltp
+IMG := $(IMG_PREFIX):$(IMG_TAG)
+
+
+build:
+	$(CONTAINER_CMD) build --file $(CURDIR)/Containerfile --tag $(IMG)
+
+push:
+	$(CONTAINER_CMD) push $(IMG)
+
+clean:
+	$(CONTAINER_CMD) rmi --force $(IMG)
+

--- a/testcases/containers/images/ltp/run_ltp.sh
+++ b/testcases/containers/images/ltp/run_ltp.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+SELF=$(basename "${BASH_SOURCE[0]}")
+TESTDIR="${1:-"/testdir"}"
+
+declare -a LTP_TESTS=(
+	"aio01"
+	"aio02"
+	"chdir04"
+	"close01"
+	"close02"
+	"creat01"
+	"creat03"
+	"diotest1"
+	"diotest2"
+	"diotest3"
+	"diotest5"
+	"diotest6"
+	"faccessat01"
+	"fdatasync01"
+	"fdatasync02"
+	"fgetxattr03"
+	"flock01"
+	"flock02"
+	"flock03"
+	"flock04"
+	"flock06"
+	"fstatfs02"
+	"fsync02"
+	"ftest01"
+	"ftest02"
+	"ftest03"
+	"ftest04"
+	"ftest05"
+	"ftest06"
+	"ftest07"
+	"ftest08"
+	"ftruncate01"
+	"ftruncate03"
+	"inode01"
+	"inode02"
+	"lftest"
+	"link02"
+	"link03"
+	"link05"
+	"llseek01"
+	"llseek02"
+	"llseek03"
+	"lseek01"
+	"lseek07"
+	"mkdirat01"
+	"mknodat01"
+	"mmap001"
+	"mmap01"
+	"mmap02"
+	"mmap03"
+	"mmap04"
+	"mmap05"
+	"mmap06"
+	"mmap08"
+	"mmap09"
+	"mmap12"
+	"mmap13"
+	"mmap17"
+	"mmap18"
+	"mmap19"
+	"mmap20"
+	"munmap01"
+	"munmap02"
+	"munmap03"
+	"open03"
+	"open09"
+	"open13"
+	"openat01"
+	"openfile"
+	"pread01"
+	"pread02"
+	"preadv01"
+	"preadv02"
+	"preadv201"
+	"preadv202"
+	"pwrite01"
+	"pwrite02"
+	"pwrite03"
+	"pwrite04"
+	"pwritev01"
+	"pwritev02"
+	"pwritev201"
+	"pwritev202"
+	"read01"
+	"read02"
+	"read04"
+	"readahead01"
+	"readdir01"
+	"readv01"
+	"readv02"
+	"removexattr01"
+	"removexattr02"
+	"rename14"
+	"rmdir01"
+	"stat02"
+	"truncate02"
+	"unlink07"
+	"write01"
+	"write02"
+	"write03"
+	"write05"
+	"write06"
+	"writev01"
+	"writev02"
+	"writev05"
+	"writev06"
+	"writev07"
+)
+
+_msg() { echo "$SELF: $*" >&2; }
+_die() { _msg "$*"; exit 1; }
+_try() { ( "$@" ) || _die "failed: $*"; }
+_run() { echo "$SELF: $*" >&2; _try "$@"; }
+
+_sit_pre_ltp_tests() {
+	export LTPROOT="/opt/ltp"
+	export LTP_COLORIZE_OUTPUT=0
+	export LTP_TIMEOUT_MUL=10
+	export TMPDIR="${TESTDIR}"
+	export PATH="${PATH}:${LTPROOT}/testcases/bin"
+	export FSSTRESS_PROG="${LTPROOT}/testcases/bin/fsstress"
+
+	mkdir -p "${TESTDIR}"
+	_msg "LTPROOT=${LTPROOT}"
+	_msg "TMPDIR=${TMPDIR}"
+}
+
+_sit_run_ltp_tests() {
+	local test_path
+
+	for test in "${LTP_TESTS[@]}"; do
+		test_path="${LTPROOT}/testcases/bin/${test}"
+		_run "${test_path}"
+	done
+}
+
+_sit_run_ltp_fsstress_with() {
+	_run ${FSSTRESS_PROG} "$@" -d "${TMPDIR}"
+}
+
+_sit_run_ltp_fsstress() {
+	_sit_run_ltp_fsstress_with -n 1 -p 1 -r
+	_sit_run_ltp_fsstress_with -n 10 -p 10 -r
+	_sit_run_ltp_fsstress_with -n 1000 -p 10 -r \
+		-f creat=1000 -f read=100 -f write=100 \
+		-f stat=100 -f mkdir=100 -f getdents=100 \
+		-f truncate=10
+}
+
+
+_sit_pre_ltp_tests
+_sit_run_ltp_tests
+_sit_run_ltp_fsstress
+
+

--- a/testcases/containers/test_containers.yml
+++ b/testcases/containers/test_containers.yml
@@ -1,3 +1,5 @@
 ---
 - name: "smallfiles"
   url: "quay.io/samba.org/sit-test-cases:smallfiles"
+- name: "ltp"
+  url: "quay.io/samba.org/sit-test-cases:ltp"


### PR DESCRIPTION
Use well-known open-source LTP[1] test-suits over mounted smb-share, using containerized image. Uses only a subset of tests to check mounted SMB share via podman container. Use also LTP's fsstress utility to tests few cases.

Image URL: `quay.io/samba.org/sit-test-cases:ltp`

[1] https://linux-test-project.github.io/