### PR TITLE
Cleanup io

### DIFF
--- a/testcases/misc/test_dbm.py
+++ b/testcases/misc/test_dbm.py
@@ -92,7 +92,7 @@ def _check_dbm_consistency(base: Path, nrecs: int) -> None:
 
 
 def _run_dbm_consistency_checks(base_path: Path) -> None:
-    base_path.mkdir(parents=True, exist_ok=True)
+    base_path.mkdir(exist_ok=True)
     try:
         _check_dbm_consistency(base_path, 10)
         _check_dbm_consistency(base_path, 100)

--- a/testcases/misc/test_io.py
+++ b/testcases/misc/test_io.py
@@ -101,12 +101,10 @@ def _run_checks(dsets: typing.List[DataPath]) -> None:
         dset.verify_noent()
 
 
-def _check_io_consistency(test_dir: Path) -> None:
-    base = None
+def _check_io_consistency(base: Path) -> None:
     try:
         print("\n")
-        base = test_dir / "test_io_consistency"
-        base.mkdir(parents=True)
+        base.mkdir()
         # Case-1: single 4K file
         _run_checks(_make_datasets(base, 4096, 1))
         # Case-2: single 16M file
@@ -136,9 +134,11 @@ def _perform_io_consistency_check(directory: Path) -> None:
 
 @pytest.mark.parametrize("setup_mount", gen_params(), indirect=True)
 def test_check_io_consistency(setup_mount: Path) -> None:
-    _perform_io_consistency_check(setup_mount)
+    base = setup_mount / "test_io_consistency"
+    _perform_io_consistency_check(base)
 
 
 @pytest.mark.parametrize("test_dir", gen_params_premounted())
 def test_check_io_consistency_premounted(test_dir: Path) -> None:
-    _perform_io_consistency_check(test_dir)
+    base = test_dir / "test_io_consistency"
+    _perform_io_consistency_check(base)

--- a/testcases/misc/test_stress.py
+++ b/testcases/misc/test_stress.py
@@ -1,6 +1,7 @@
 import pytest
 import threading
 import testhelper
+import shutil
 from pathlib import Path
 from .conftest import gen_params, gen_params_premounted
 
@@ -46,16 +47,22 @@ def _stress_test(
 
 
 def _run_stress_tests(directory: Path) -> None:
-    _stress_test(
-        directory, num_clients=20, num_operations=40, file_size=2**25
-    )
+    directory.mkdir(exist_ok=True)
+    try:
+        _stress_test(
+            directory, num_clients=20, num_operations=40, file_size=2**25
+        )
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
 
 
 @pytest.mark.parametrize("setup_mount", gen_params(), indirect=True)
 def test_check_mnt_stress(setup_mount: Path) -> None:
-    _run_stress_tests(setup_mount)
+    base = setup_mount / "stress-test"
+    _run_stress_tests(base)
 
 
 @pytest.mark.parametrize("test_dir", gen_params_premounted())
 def test_check_mnt_stress_premounted(test_dir: Path) -> None:
-    _run_stress_tests(test_dir)
+    base = test_dir / "stress-test"
+    _run_stress_tests(base)


### PR DESCRIPTION
Clean up io tests to
a) make the creation and deletion of test subdirectory consistent among tests
b) Run stress test within a sub directory.