### PR TITLE
test_mount_stress: include single stress test

### DIFF
--- a/testcases/mount/test_mount_stress.py
+++ b/testcases/mount/test_mount_stress.py
@@ -47,16 +47,7 @@ def _stress_test(
 
 def _run_stress_tests(directory: Path) -> None:
     _stress_test(
-        directory, num_clients=5, num_operations=20, file_size=2**22
-    )
-    _stress_test(
-        directory, num_clients=10, num_operations=30, file_size=2**23
-    )
-    _stress_test(
-        directory, num_clients=20, num_operations=40, file_size=2**24
-    )
-    _stress_test(
-        directory, num_clients=15, num_operations=25, file_size=2**25
+        directory, num_clients=20, num_operations=40, file_size=2**25
     )
 
 


### PR DESCRIPTION
With this change we are including one stress test with near maximum values i.e num_clients=20, num_operations=40, file_size=2**25

Other existing tests with lower values are eliminated as the goal here should be to test with maximum stress. Tests with lower values are needless when the test with maximum stress passes.

Fixes: #54