### PR TITLE
tox: flake8 - exclude directories starting with .

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,3 +45,9 @@ deps =
     types-python-dateutil
 changedir = {toxinidir}
 commands = mypy --no-color-output .
+
+[flake8]
+exclude =
+    .tox,
+    .venv,
+    __pycache__


### PR DESCRIPTION
I use a .venv directory within the repo and flake8 ends up checking the python modules within that directory. So I add a flake8 section to tox.ini and exclude .venv and a few other directories from flake8 checks.

This will come useful in the next series of patches where I update the testcases/smbtorture/selfhelp/* files from the samba sources which fail flake8. At the moment, we have updated the .py files in the directory to pass flake8 checks. This is unnecessary. By excluding this folder, we will make maintenance easier.