### PR TITLE
flapping.cephfs: Add specific `smb2.session` tests as knownfail

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs
@@ -4,3 +4,7 @@
 # This is a known fail for samba4 env. We explicitly mark env as
 # samba3 which means we don't ever match with this knownfail.
 ^samba3.smb2.create.quota-fake-file
+
+# Ignore due to lack of proper multichannel setup.
+^samba3.smb2.session.bind2
+^samba3.smb2.session.two_logoff


### PR DESCRIPTION
Many of the tests from `smb2.session` torture suite are already failing on XFS for which _flapping.xfs_ already contains an entry to skip any such failures. With recent update to selftest entries from upstream, compared to _flapping.xfs_ we are left with only one failure(`smb2.session.reauth4`) which needs to be investigated before adding it to the flapping list.