### PR TITLE
testinfo.yml: reintroduce testinfo.yml.example

### DIFF
--- a/test-info.yml.example
+++ b/test-info.yml.example
@@ -1,0 +1,20 @@
+private_interfaces:
+  - "192.168.122.100"
+  - "192.168.122.101"
+
+public_interfaces:
+  - "192.168.123.10"
+  - "192.168.123.11"
+
+exported_sharenames:
+  - "gluster-vol"
+
+test_users:
+  - {"username": "test1", "password": "x"}
+  - {"username": "test2", "password": "x"}
+
+test_backend: glusterfs
+
+premounted_shares:
+  - "/testdir1"
+  - "/testdir2"


### PR DESCRIPTION
This particular file was incorrectly removed by the patch 
0e09247 (Introduce setup and teardown fixture, 2023-11-22)

Reintroduce this file.