### PR TITLE
Tox deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     pytest
     pyyaml
     pytest-randomly
+    iso8601
 commands = pytest -vrfEsxXpP testcases/
 
 [testenv:pytest-unprivileged]
@@ -23,6 +24,7 @@ deps =
     pytest
     pyyaml
     pytest-randomly
+    iso8601
 commands = pytest -vrfEsxXpP -k 'not privileged' testcases/
 
 [testenv:sanity]
@@ -30,6 +32,7 @@ deps =
     pytest
     pyyaml
     pytest-randomly
+    iso8601
 changedir = {toxinidir}
 commands = pytest -vrfEsxXpP testcases/consistency
 


### PR DESCRIPTION
Add required python dependency iso8601 to tox.ini

depends on #61 