### PR TITLE
pyproject.toml: register pytest mark privileged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,7 @@ exclude = [
     "^testcases/smbtorture/selftest",
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "privileged: marks tests as requiring to be run as privileged processes.",
+]


### PR DESCRIPTION
f53d5d3 testcases: mark certain tests as privileged

Introduced the custom mark privileged to mark out tests which need to be run as privileged processes. However this leads to warning messages seen in the warnings summary for the tests.

We register these custom marks to avoid these warning messages.