### PR TITLE
flapping.xfs: Do not consider entire smb2.session as knownfail

### DIFF
--- a/testcases/smbtorture/selftest/flapping.xfs
+++ b/testcases/smbtorture/selftest/flapping.xfs
@@ -2,4 +2,6 @@
 # samba3 which means we don't ever match with this knownfail.
 ^samba3.smb2.create.quota-fake-file
 
-^samba3.smb2.session.*
+# Ignore due to lack of proper multichannel setup.
+^samba3.smb2.session.bind2
+^samba3.smb2.session.two_logoff


### PR DESCRIPTION
Most of the tests from _smb2.session_ test suite passes successfully on XFS without any extra setup. Therefore be specific about subtests which are to be ignored due to lack of special and/or proper server setup.