### PR TITLE
smbtorture: smb2.bench-oplock no longer exists

### DIFF
--- a/testcases/smbtorture/smbtorture-tests-info.yml
+++ b/testcases/smbtorture/smbtorture-tests-info.yml
@@ -1,7 +1,6 @@
 ---
 - smb2.rw
 - smb2.read
-- smb2.bench-oplock
 - smb2.check-sharemode
 - smb2.compound_find
 - smb2.connect


### PR DESCRIPTION
`smb2.bench-oplock` got renamed to `smb2.bench.oplock` as a separate test within `smb2.bench` test suite. Subsequently more tests got added into `smb2.bench`. Let's remove the old `smb2.bench-oplock` entry and re-add the test suite after checking feasibility of running the independent tests.

Thanks to @spuiuk for pointing out the following smbtorture notice from our test runs:
```
_____________ test_smbtorture[share-xfs-default-smb2.bench-oplock] _____________
----------------------------- Captured stdout call -----------------------------
Command: /bin/smbtorture --fullname --option=torture:progress=no --option=torture:sharedelay=100000 --option=torture:writetimeupdatedelay=500000 --format=subunit --target=samba3 --user=test2%x //192.168.123.10/share-xfs-default smb2.bench-oplock|/usr/bin/python3 /root/sit-test-cases/testcases/smbtorture/selftest/filter-subunit --fail-on-empty --prefix=samba3. --expected-failures=/root/sit-test-cases/testcases/smbtorture/selftest/knownfail --expected-failures=/root/sit-test-cases/testcases/smbtorture/selftest/knownfail.d --expected-failures=/root/sit-test-cases/testcases/smbtorture/selftest/expectedfail.d --flapping=/root/sit-test-cases/testcases/smbtorture/selftest/flapping --flapping=/root/sit-test-cases/testcases/smbtorture/selftest/flapping.d --flapping=/root/sit-test-cases/testcases/smbtorture/selftest/flapping.xfs|/usr/bin/python3 /root/sit-test-cases/testcases/smbtorture/selftest/format-subunit


smbtorture 4.21.0pre1-UNKNOWN
Using seed 1709679416
time: 2024-03-05 22:56:56.178866Z
Unknown torture operation 'smb2.bench-oplock'


smbtorture 4.21.0pre1-UNKNOWN
Using seed 1709679416
Unknown torture operation 'smb2.bench-oplock'

ALL OK (0 tests in 0 testsuites)

There might be more detail in ./subunit or ./summary.
```