### PR TITLE
smbtorture/selftest: Add flapping.gpfs

### DIFF
--- a/testcases/smbtorture/selftest/flapping.gpfs
+++ b/testcases/smbtorture/selftest/flapping.gpfs
@@ -1,0 +1,7 @@
+# This is a known fail for samba4 env. We explicitly mark env as
+# samba3 which means we don't ever match with this knownfail.
+^samba3.smb2.create.quota-fake-file
+
+# Ignore due to lack of proper multichannel setup.
+^samba3.smb2.session.bind2
+^samba3.smb2.session.two_logoff


### PR DESCRIPTION
Use a dedicated flapping list similar to what we have for XFS to start with filtering GPFS smbtorture test run results.