### PR TITLE
tox: cleanup tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
-
 [tox]
-envlist = pytest, sanity, flake8, black, mypy, py39, py310, py311
+envlist = flake8, black, mypy
 isolated_build = True
 
 [testenv]
-minversion = 3.9
 passenv =
     TEST_INFO_FILE
     PYTHONPATH
-deps = pytest
-commands = py.test -v .
 
 [testenv:pytest]
 deps =


### PR DESCRIPTION
1) The minversion directive used is meant to set minimum tox version and
   not the python version to be used. It is hence used incorrectly here.
2) Set the default tox action run to the code checking tools only.