### PR TITLE
smbtorture: Add more smb2 tests

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs
@@ -16,3 +16,6 @@ samba3.smb2.timestamps.time_t_10000000000
 samba3.smb2.timestamps.time_t_-1
 samba3.smb2.timestamps.time_t_-2
 samba3.smb2.timestamps.time_t_1968
+
+# https://github.com/samba-in-kubernetes/sit-test-cases/issues/80
+samba3.smb2.durable-open.alloc-size

--- a/testcases/smbtorture/selftest/knownfail
+++ b/testcases/smbtorture/selftest/knownfail
@@ -214,7 +214,7 @@
 ^samba3.smb2.streams streams_xattr.rename2\(nt4_dc\)
 ^samba3.smb2.getinfo.complex
 ^samba3.smb2.getinfo.fsinfo # quotas don't work yet
-^samba3.smb2.setinfo.setinfo
+^samba3.smb2.setinfo
 ^samba3.smb2.session.*reauth5 # some special anonymous checks?
 ^samba3.smb2.compound.interim2 # wrong return code (STATUS_CANCELLED)
 ^samba3.smb2.compound.aio.interim2 # wrong return code (STATUS_CANCELLED)

--- a/testcases/smbtorture/smbtorture-tests-info.yml
+++ b/testcases/smbtorture/smbtorture-tests-info.yml
@@ -31,3 +31,7 @@
 - smb2.bench
 - smb2.winattr2
 - smb2.charset
+- smb2.dir
+- smb2.durable-open
+- smb2.setinfo
+- smb2.delete-on-close-perms


### PR DESCRIPTION
Here we update selftest/knownfail as _smb2.setinfo_ is a single test and not a test suite. Hopefully with the next sync of selftest contents from upstream we get it resolved via [!3647](https://gitlab.com/samba-team/samba/-/merge_requests/3647).

The pull request depends on [!3635](https://gitlab.com/samba-team/samba/-/merge_requests/3635) and [!3649](https://gitlab.com/samba-team/samba/-/merge_requests/3649) in order to successfully pass _smb2.durable-open_ and _smb2.delete-on-close-perms_ respectively.