### PR TITLE
tox: list the time taken to run each test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     pytest-randomly
     iso8601
     smbprotocol
-commands = pytest -vrfEsxXpP testcases/
+commands = pytest -vrfEsxXpP testcases/ --durations=0
 
 [testenv:pytest-unprivileged]
 deps =
@@ -23,7 +23,7 @@ deps =
     pytest-randomly
     iso8601
     smbprotocol
-commands = pytest -vrfEsxXpP -k 'not privileged' testcases/
+commands = pytest -vrfEsxXpP -k 'not privileged' testcases/ --durations=0
 
 [testenv:sanity]
 deps =


### PR DESCRIPTION
Output the time required to setup, call and teardown each test. We only report times which take longer than 0.05 seconds.

This information can be used to compare performance against differing setups.