### PR TITLE
Add smb2.session.reauth4 to flapping list for XFS and CephFS(kclient)

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs
@@ -16,3 +16,7 @@ samba3.smb2.timestamps.time_t_10000000000
 samba3.smb2.timestamps.time_t_-1
 samba3.smb2.timestamps.time_t_-2
 samba3.smb2.timestamps.time_t_1968
+
+# https://github.com/samba-in-kubernetes/sit-environment/pull/109
+# Note: CephFS(vfs) successfully completes smb2.session.reauth4.
+samba3.smb2.session.reauth4

--- a/testcases/smbtorture/selftest/flapping.xfs
+++ b/testcases/smbtorture/selftest/flapping.xfs
@@ -5,3 +5,6 @@
 # Ignore due to lack of proper multichannel setup.
 ^samba3.smb2.session.bind2
 ^samba3.smb2.session.two_logoff
+
+# https://github.com/samba-in-kubernetes/sit-environment/pull/109
+samba3.smb2.session.reauth4


### PR DESCRIPTION
With recent changes to _[smb.conf](https://github.com/samba-in-kubernetes/sit-environment/pull/109)_, _smb2.session.reauth4_ is expected to fail on XFS and CephFS kclient method. You can find more details from https://github.com/samba-in-kubernetes/sit-environment/pull/109#issuecomment-2208737127.

Also remember that this is **_not a problem with CephFS vfs_** approach but our clone of selftest mechanism currently lacks the ability to consider flapping lists based on variants for a particular backend.