### PR TITLE
selftest: Add a dedicated flapping list for CephFS vfs

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs-vfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs-vfs
@@ -1,0 +1,18 @@
+# https://github.com/samba-in-kubernetes/sit-test-cases/issues/35
+^samba3.smb2.rw.invalid
+
+# This is a known fail for samba4 env. We explicitly mark env as
+# samba3 which means we don't ever match with this knownfail.
+^samba3.smb2.create.quota-fake-file
+
+# Ignore due to lack of proper multichannel setup.
+^samba3.smb2.session.bind2
+^samba3.smb2.session.two_logoff
+
+# https://github.com/samba-in-kubernetes/sit-test-cases/issues/71
+# https://tracker.ceph.com/issues/65043
+samba3.smb2.timestamps.time_t_15032385535
+samba3.smb2.timestamps.time_t_10000000000
+samba3.smb2.timestamps.time_t_-1
+samba3.smb2.timestamps.time_t_-2
+samba3.smb2.timestamps.time_t_1968


### PR DESCRIPTION
With certain samba configurations we might require a separate flapping list for variants of a backend. One such situation is detailed in https://github.com/samba-in-kubernetes/sit-environment/pull/109 where specific test run results differ among variants of a particular backend.