### PR TITLE
test-info.yml: add filesystem variant to the backend

### DIFF
--- a/test-info.yml.example
+++ b/test-info.yml.example
@@ -18,7 +18,9 @@ shares:
     path: /mnt/share/export1-cephfs-vfs
     backend:
       # If present override default backend filesystem
-      name: cephfs.vfs
+      name: cephfs
+      # If present list the variant of the backend filesystem
+      variant: vfs
     # If present, use these credentials to perform the
     # tests for this share
     users:


### PR DESCRIPTION
This helps us tailor tests for cases where the behaviour changes according to the filesystem variant being used.

In this case, we use it with the smbtorture tests where we select the flapping list for the filesystem-variant and it it doesn't exist, fall back to filesystem file.