### PR TITLE
testcases/containers: variable not used/assigned

### DIFF
--- a/testcases/containers/test_containers.py
+++ b/testcases/containers/test_containers.py
@@ -24,7 +24,7 @@ container_tests: typing.Dict[str, str] = {}
 
 
 def load_container_tests() -> int:
-    global container_tests
+    # This modifies the global container_tests
     with open(container_tests_file) as f:
         ct = yaml.safe_load(f)
     if ct is None:


### PR DESCRIPTION
flake8 complains that global container_tests is unused and it is never assigned in scope.

Fixed the same by removing the unused global declaration within the function and adding an appropriate comment.