### PR TITLE
smbtorture: Add accented character test to flapping.cephfs

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs
@@ -20,3 +20,8 @@ samba3.smb2.timestamps.time_t_1968
 # https://github.com/samba-in-kubernetes/sit-environment/pull/109
 # Note: CephFS(vfs) successfully completes smb2.session.reauth4.
 samba3.smb2.session.reauth4
+
+# Accented character test is expected to fail on case insensitive subvolumes
+# due to unicode normalization which results in same unicode character even
+# if composed using two different unicode encodings.
+^samba3.smb2.charset.*.Testing composite character \(a umlaut\)


### PR DESCRIPTION
_smb2.charset_ contains a composite character test attempting to create accented character which could fail on case insensitive CephFS subvolumes. Therefore add the corresponding test to the flapping list for CephFS.

> smbtorture 4.24.0pre1-UNKNOWN
> Using seed 1756437765
> time: 2025-08-29 03:22:45.742934Z
> progress: 4
> test: samba3.smb2.charset.Testing composite character (a umlaut)
> time: 2025-08-29 03:22:45.743692Z
> time: 2025-08-29 03:22:45.894823Z
> **failure**: samba3.smb2.charset.Testing composite character (a umlaut) [
> Exception: ../../source4/torture/smb2/charset.c:119: status was NT_STATUS_OBJECT_NAME_COLLISION, expected NT_STATUS_OK: Failed to create accented character
> 
> ]