### PR TITLE
smbtorture: Add `modern_write_time_update-1` test to flapping.cephfs

### DIFF
--- a/testcases/smbtorture/selftest/flapping.cephfs
+++ b/testcases/smbtorture/selftest/flapping.cephfs
@@ -25,3 +25,7 @@ samba3.smb2.session.reauth4
 # due to unicode normalization which results in same unicode character even
 # if composed using two different unicode encodings.
 ^samba3.smb2.charset.*.Testing composite character \(a umlaut\)
+
+# https://github.com/samba-in-kubernetes/sit-test-cases/issues/101
+# https://tracker.ceph.com/issues/71622
+samba3.smb2.timestamps.modern_write_time_update-1


### PR DESCRIPTION
_smb2.timestamps.modern_write_time_update-1_ does not run successfully on non-proxy enabled CephFS shares due to an underlying bug which is reported via tracker [#71622](https://tracker.ceph.com/issues/71622). For now we add it to the flapping list until the issue is fixed.