### PR TITLE
testhelper: Fix mypy return-value error in generate_random_bytes

### DIFF
--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -122,7 +122,7 @@ def generate_random_bytes(size: int) -> bytes:
         rem = size - len(rba)
         rnd = bytearray(random.randbytes(min(rem, 1024)))
         rba = rba + rnd + rba
-    return rba[:size]
+    return bytes(rba[:size])
 
 
 def get_shares(test_info: dict) -> dict:


### PR DESCRIPTION
Since _mypy_ 2.0, --strict-bytes is [enabled by default](https://mypy.readthedocs.io/en/stable/changelog.html#enable-strict-bytes-by-default) as per [PEP 688](https://peps.python.org/pep-0688/), so _bytearray_ is no longer assignable to _bytes_. Wrap the return value with _bytes()_ to match the declared return type.